### PR TITLE
Fix module import name issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/jason0x43/go-alfred
+
+go 1.13
+
+require (
+	github.com/Masterminds/semver v1.5.0
+	github.com/blang/semver v3.5.1+incompatible
+	howett.net/plist v0.0.0-20181124034731-591f970eefbb
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+howett.net/plist v0.0.0-20181124034731-591f970eefbb h1:jhnBjNi9UFpfpl8YZhA9CrOqpnJdvzuiHsl/dnxl11M=
+howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=

--- a/plist.go
+++ b/plist.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	plist "github.com/DHowett/go-plist"
+	"howett.net/plist"
 )
 
 // Plist is a plist data structure


### PR DESCRIPTION
When trying to install `alfred` utility I got issues with a module:

```
go install github.com/jason0x43/go-alfred/alfred
go: finding github.com/jason0x43/go-alfred latest
go: finding github.com/DHowett/go-plist latest
go: github.com/jason0x43/go-alfred/alfred imports
	github.com/jason0x43/go-alfred imports
	github.com/DHowett/go-plist: github.com/DHowett/go-plist@v0.0.0-20181124034731-591f970eefbb: parsing go.mod:
	module declares its path as: howett.net/plist
	        but was required as: github.com/DHowett/go-plist
```

Apparently the module name is defined as `howett.net/plist`  https://github.com/DHowett/go-plist/blob/master/go.mod#L1

I also added `go.mod` and `go.sum`.

I tested it by building locally and I had no issues then :) 